### PR TITLE
add paramater for managing default_shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,8 @@ class { '::tmux':
   * Accepted valued: true or false
   * Default: true
   * Description: Adds a clock to the status bar
+
+* default_shell
+  * Accepted values: string or default
+  * Default: undefined
+  * Description: Optionally specify a default shell.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class tmux (
   $vi_mode_keys     = $tmux::params::vi_mode_keys,
   $pretty_statusbar = $tmux::params::pretty_statusbar,
   $clock            = $tmux::params::clock,
+  $default_shell    = $tmux::params::default_shell,
 ) inherits tmux::params {
 
   if $ensure == true {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,4 +19,5 @@ class tmux::params {
   $vi_mode_keys     = true
   $pretty_statusbar = true
   $clock            = true
+  $default_shell    = undef
 }

--- a/templates/tmux.conf.erb
+++ b/templates/tmux.conf.erb
@@ -6,6 +6,12 @@
     @prefix_key = 'C-a'
   end
 -%>
+
+<% if @default_shell -%>
+    # set shell
+    set -g default-shell <%= @default_shell -%>
+<% end -%>
+
 # use utf8
 set -g utf8
 set-window-option -g utf8 on


### PR DESCRIPTION
Didn't do the tests apologies, wasn't quite sure how.
In our environment we find it useful to configure the default shell when using tmux, because not all shared root users want zsh for example, however all tmux users, here, typically want zsh.
