### PR TITLE
allow ensure to be "present" as well as true

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class tmux (
   $default_shell    = $tmux::params::default_shell,
 ) inherits tmux::params {
 
-  if $ensure == true {
+  if $ensure == true or $ensure == "present" {
     if $auto_update == true {
       $version = 'latest'
     } else {


### PR DESCRIPTION
The readme says ensure can be
Accepted values: present or absent
and that the default is present.  But really it is true not present.
So added code to allow it to be either true or present since present is pretty commonly used for ensure.